### PR TITLE
Fix folder creation failing on MacOS

### DIFF
--- a/main.js
+++ b/main.js
@@ -186,7 +186,18 @@ function pathBaseName(filename) {
 function extractBookTitle(volumeId) {
   // Assuming volumeId is a path-like string, extract the last segment
   const parts = volumeId.split('/');
-  return parts[parts.length - 1] || 'UnknownBook';
+  let title = parts[parts.length - 1] || 'UnknownBook';
+  
+  // Replace dots with underscores to preserve file extensions
+  title = title.replace(/\./g, '_');
+  
+  // Further sanitize the title for use as a directory name
+  return sanitizeDirectoryName(title);
+}
+
+function sanitizeDirectoryName(dirName) {
+  // Remove illegal characters but keep the underscores that replaced dots
+  return dirName.replace(/[\/\\?%*:|"<>]/g, '_');
 }
 
 function getVolumeId(base, db) {


### PR DESCRIPTION
Hello! First off, thank you so much for this little tool. I was shocked to learn there is no official way to export markup annotations from Kobo, and was on my way to make my own tool when I stumbled upon yours.

I'm a MacOS user and have encountered an issue that does not throw any errors but fails to write the files. Here's some more information:

### Issue
When running the script on MacOS, book folder creation fails when the book title contains extensions (like `.epub` or `.kepub.epub`). 
While on Windows the script creates directories as `Booktitle.epub`, on MacOS file/directory names with extensions are handled differently. Instead of creating directories, the script creates _files_ named `Booktitle.epub` directly in the output directory. So there's no actual directories, and the `.png` files do not get written anywhere.

### Proposed fix
I modified the `extractBookTitle` function to replace dots with underscores in directory names.

For example:
- "Booktitle.epub" becomes "Booktitle_epub" 
- "Booktitle.kepub.epub" becomes "Booktitle_kepub_epub"

This ensures consistent behavior across both Windows and MacOS while keeping a reference to the original file format.

Let me know if any of this isn't clear. I've tested the change on both MacOS and Windows and seems to work fine.